### PR TITLE
Modernise dokku review app workflow

### DIFF
--- a/.github/workflows/dokku-pr.yaml
+++ b/.github/workflows/dokku-pr.yaml
@@ -3,8 +3,12 @@ name: 'deploy-pr'
 on:
   pull_request
 
+env:
+  REVIEW_APP_NAME: "${{ github.event.pull_request.base.repo.name }}-review-${{ github.event.pull_request.number }}"
+  GIT_REMOTE_URL: 'ssh://dokku@c.iphoting.cc:3022/camo'
+
 jobs:
-  review_app:
+  create_review_app:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.action == 'opened'
     steps:
@@ -12,22 +16,39 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Push to dokku
-        uses: dokku/github-action@v1.4.0
+      - name: Create review app
+        uses: dokku/github-action@v1.10.0
         with:
           command: review-apps:create
-          review_app_name: "${{ github.event.pull_request.base.repo.name }}-review-${{ github.event.pull_request.number }}"
-          git_remote_url: 'ssh://dokku@c.iphoting.cc:3022/camo'
+          review_app_name: ${{ env.REVIEW_APP_NAME }}
+          git_remote_url: ${{ env.GIT_REMOTE_URL }}
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+  deploy_review_app:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action != 'opened' && github.event.action != 'closed'
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Deploy to review app
+        uses: dokku/github-action@v1.10.0
+        with:
+          review_app_name: ${{ env.REVIEW_APP_NAME }}
+          git_remote_url: ${{ env.GIT_REMOTE_URL }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
 
   destroy_review_app:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     steps:
-      - name: Destroy the review app
-        uses: dokku/github-action@v1.4.0
+      - name: Cloning repo
+        uses: actions/checkout@v4
+      - name: Destroy review app
+        uses: dokku/github-action@v1.10.0
         with:
           command: review-apps:destroy
-          review_app_name: "${{ github.event.pull_request.base.repo.name }}-review-${{ github.event.pull_request.number }}"
-          git_remote_url: 'ssh://dokku@c.iphoting.cc:3022/camo'
+          review_app_name: ${{ env.REVIEW_APP_NAME }}
+          git_remote_url: ${{ env.GIT_REMOTE_URL }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Add `deploy_review_app` job so review apps receive subsequent pushes — previously the workflow only created and destroyed, meaning code changes pushed after a PR was opened were never deployed to the review app
- Add checkout to `destroy_review_app` (required if destroy hooks are configured on the Dokku side)
- Extract repeated `REVIEW_APP_NAME` and `GIT_REMOTE_URL` into workflow-level `env` vars

Based on the upstream example: https://github.com/dokku/github-action/blob/b705ed643fea68530501b1faf37abe233caa06be/example-workflows/review-app.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)